### PR TITLE
Add test for all commponents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+src/__snapshots__
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   - [🛠 Built With ](#-built-with-)
     - [Tech Stack ](#tech-stack-)
     - [Key Features ](#key-features-)
+  - [� Live Demo ](#-live-demo-)
   - [💻 Getting Started ](#-getting-started-)
     - [Setup](#setup)
     - [Install](#install)
@@ -39,6 +40,10 @@
 - **Use JSX**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## 🚀 Live Demo <a name="live-demo"></a>
+
+[Live Demo Link](https://math-magiciens-trast00.onrender.com/calculator)
 
 ## 💻 Getting Started <a name="getting-started"></a>
 
@@ -82,8 +87,9 @@ To run the project, execute the following command:
 
 ## 🔭 Future Features <a name="future-features"></a>
 
-- [ ] **Add a calculator**
-- [ ] **Single Page App**
+- [x] **Add a calculator**
+- [x] **Single Page App**
+- [ ] **Add history for calculator**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "big.js": "^6.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.6.2",
         "react-scripts": "5.0.1",
+        "react-test-renderer": "^18.2.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -24,6 +24,7 @@
         "@babel/plugin-syntax-jsx": "^7.18.6",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
+        "@testing-library/react": "^13.4.0",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-plugin-import": "^2.26.0",
@@ -3615,6 +3616,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
       "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",
@@ -4106,7 +4108,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4127,6 +4130,7 @@
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4137,6 +4141,7 @@
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4157,7 +4162,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -6469,7 +6475,8 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -15690,6 +15697,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -21625,6 +21662,7 @@
       "version": "13.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
       "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",
@@ -22043,7 +22081,8 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.5",
@@ -22064,6 +22103,7 @@
       "version": "18.0.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
       "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -22074,6 +22114,7 @@
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -22094,7 +22135,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -23771,7 +23813,8 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -30265,6 +30308,32 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
+    },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "requires": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "big.js": "^6.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.2",
     "react-scripts": "5.0.1",
+    "react-test-renderer": "^18.2.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -43,6 +43,7 @@
     "@babel/plugin-syntax-jsx": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
+    "@testing-library/react": "^13.4.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.26.0",

--- a/src/App.css
+++ b/src/App.css
@@ -136,6 +136,7 @@
   color: #ff5c5c;
   background-color: #303137;
   cursor: pointer;
+  
 }
 
 .calculator-btns > *:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -107,6 +107,7 @@
   font-weight: 600;
   padding: 12px 18px 12px 16px;
   border: none;
+  overflow: hidden;
   background-color: #17181a;
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;

--- a/src/App.css
+++ b/src/App.css
@@ -136,7 +136,6 @@
   color: #ff5c5c;
   background-color: #303137;
   cursor: pointer;
-  
 }
 
 .calculator-btns > *:hover {

--- a/src/components.test.js
+++ b/src/components.test.js
@@ -40,8 +40,8 @@ describe('Test navigation', () => {
 
   test('test naviation to calculator', () => {
     render(<App />);
-    const btnQuote = screen.getByText('Calculator');
-    fireEvent.click(btnQuote);
+    const btnCalculator = screen.getByText('Calculator');
+    fireEvent.click(btnCalculator);
     const titles = screen.getAllByRole('heading');
     expect(titles[1]).toHaveTextContent(calculatorHeading);
     expect(titles.indexOf(quoteHeading)).toBe(-1);
@@ -52,10 +52,10 @@ describe('Test navigation', () => {
 describe('Test Calculator Basic interaction', () => {
   test('test buttons interaction with screen', () => {
     render(<App />);
-    const btnQuote = screen.getByText('Calculator');
+    const btnCalculator = screen.getByText('Calculator');
+    fireEvent.click(btnCalculator);
     const result = screen.getAllByText('0')[0]; // first element with 0
     const btnZero = screen.getAllByText('0')[1]; // zero btn
-    fireEvent.click(btnQuote);
 
     fireEvent.click(screen.getByText('2'));
     fireEvent.click(btnZero);
@@ -67,9 +67,9 @@ describe('Test Calculator Basic interaction', () => {
 
   test('test addiction with screen', () => {
     render(<App />);
-    const btnQuote = screen.getByText('Calculator');
+    const btnCalculator = screen.getByText('Calculator');
+    fireEvent.click(btnCalculator);
     const result = screen.getAllByText('0')[0]; // first element with 0
-    fireEvent.click(btnQuote);
 
     fireEvent.click(screen.getByText('AC'));
     fireEvent.click(screen.getByText('5'));

--- a/src/components.test.js
+++ b/src/components.test.js
@@ -1,0 +1,53 @@
+import renderer from 'react-test-renderer';
+import React from 'react';
+import {
+  render, fireEvent, screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import App from './App';
+
+const navHeading = 'Math Magicians';
+const homeHeading = 'Welcom to our page';
+const quoteHeading = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis';
+const calculatorHeading = 'Let s do some maths';
+
+describe('test rendering', () => {
+  test('test if App components render correctly', () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Test navigation', () => {
+  test('test navbar and home is displayed by default', () => {
+    render(<App />);
+    const titles = screen.getAllByRole('heading');
+    expect(titles[0]).toHaveTextContent(navHeading);
+    expect(titles[1]).toHaveTextContent(homeHeading);
+    expect(titles.indexOf(quoteHeading)).toBe(-1);
+    expect(titles.indexOf(calculatorHeading)).toBe(-1);
+  });
+
+  test('test naviation to quote', () => {
+    render(<App />);
+    const btnQuote = screen.getByText('Quotes');
+    fireEvent.click(btnQuote);
+    const titles = screen.getAllByRole('heading');
+    expect(titles[1]).toHaveTextContent(quoteHeading);
+    expect(titles.indexOf(homeHeading)).toBe(-1);
+    expect(titles.indexOf(calculatorHeading)).toBe(-1);
+  });
+
+  test('test naviation to calculator', () => {
+    render(<App />);
+    const btnQuote = screen.getByText('Calculator');
+    fireEvent.click(btnQuote);
+    const titles = screen.getAllByRole('heading');
+    expect(titles[1]).toHaveTextContent(calculatorHeading);
+    expect(titles.indexOf(quoteHeading)).toBe(-1);
+    expect(titles.indexOf(homeHeading)).toBe(-1);
+  });
+});
+
+

--- a/src/components.test.js
+++ b/src/components.test.js
@@ -7,8 +7,7 @@ import App from './App';
 
 const navHeading = 'Math Magicians';
 const homeHeading = 'Welcom to our page';
-const quoteHeading =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis';
+const quoteHeading = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis';
 const calculatorHeading = 'Let s do some maths';
 
 describe('test rendering', () => {

--- a/src/components.test.js
+++ b/src/components.test.js
@@ -1,15 +1,14 @@
 import renderer from 'react-test-renderer';
 import React from 'react';
-import {
-  render, fireEvent, screen,
-} from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import App from './App';
 
 const navHeading = 'Math Magicians';
 const homeHeading = 'Welcom to our page';
-const quoteHeading = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis';
+const quoteHeading =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis';
 const calculatorHeading = 'Let s do some maths';
 
 describe('test rendering', () => {
@@ -50,4 +49,35 @@ describe('Test navigation', () => {
   });
 });
 
+describe('Test Calculator Basic interaction', () => {
+  test('test buttons interaction with screen', () => {
+    render(<App />);
+    const btnQuote = screen.getByText('Calculator');
+    const result = screen.getAllByText('0')[0]; // first element with 0
+    const btnZero = screen.getAllByText('0')[1]; // zero btn
+    fireEvent.click(btnQuote);
 
+    fireEvent.click(screen.getByText('2'));
+    fireEvent.click(btnZero);
+    fireEvent.click(screen.getByText('2'));
+    fireEvent.click(screen.getByText('3'));
+
+    expect(result).toHaveTextContent('2023');
+  });
+
+  test('test addiction with screen', () => {
+    render(<App />);
+    const btnQuote = screen.getByText('Calculator');
+    const result = screen.getAllByText('0')[0]; // first element with 0
+    fireEvent.click(btnQuote);
+
+    fireEvent.click(screen.getByText('AC'));
+    fireEvent.click(screen.getByText('5'));
+    fireEvent.click(screen.getByText('+'));
+    fireEvent.click(screen.getByText('1'));
+    fireEvent.click(screen.getByText('2'));
+    fireEvent.click(screen.getByText('='));
+
+    expect(result).toHaveTextContent((5 + 12).toString());
+  });
+});

--- a/src/components/logic/calculate.js
+++ b/src/components/logic/calculate.js
@@ -131,3 +131,5 @@ export default function calculate(obj, buttonName) {
     operation: buttonName,
   };
 }
+
+module.exports = calculate;

--- a/src/components/logic/calculate.js
+++ b/src/components/logic/calculate.js
@@ -131,5 +131,3 @@ export default function calculate(obj, buttonName) {
     operation: buttonName,
   };
 }
-
-module.exports = calculate;

--- a/src/components/logic/calculate.test.js
+++ b/src/components/logic/calculate.test.js
@@ -1,0 +1,182 @@
+/* params: {total, next, operation}, buttonName */
+const calculate = require('./calculate');
+
+describe('test displayed on type on buttons', () => {
+  let calculeObj = { total: null, next: null, operation: null };
+
+  test('Multiple type on 0 do nothing', () => {
+    calculeObj = calculate(calculeObj, '0');
+    calculeObj = calculate(calculeObj, '0');
+    calculeObj = calculate(calculeObj, '0');
+    expect(calculeObj.next).toBe('0');
+  });
+
+  test('Typing multiple number', () => {
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '0');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '3');
+    expect(calculeObj.next).toBe('2023');
+  });
+
+  test('Clear the typed number', () => {
+    calculeObj = calculate(calculeObj, 'AC');
+    expect(calculeObj.total).toBe(null);
+    expect(calculeObj.next).toBe(null);
+    expect(calculeObj.operation).toBe(null);
+  });
+
+  test('On click on a operation clear the typed number', () => {
+    calculeObj = calculate(calculeObj, '8');
+    expect(calculeObj.next).toBe('8');
+    calculeObj = calculate(calculeObj, '+');
+    expect(calculeObj.next).toBe(null);
+    calculeObj = calculate(calculeObj, '8');
+    calculeObj = calculate(calculeObj, '-');
+    expect(calculeObj.next).toBe(null);
+    calculeObj = calculate(calculeObj, '8');
+    calculeObj = calculate(calculeObj, 'x');
+    expect(calculeObj.next).toBe(null);
+    calculeObj = calculate(calculeObj, '8');
+    calculeObj = calculate(calculeObj, '%');
+    expect(calculeObj.next).toBe(null);
+    calculeObj = calculate(calculeObj, '8');
+    calculeObj = calculate(calculeObj, '&divide;');
+    expect(calculeObj.next).toBe(null);
+  });
+
+  test('Test change sign operation', () => {
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '+/-');
+    expect(calculeObj.next).toBe('-2');
+    calculeObj = calculate(calculeObj, '+/-');
+    expect(calculeObj.next).toBe('2');
+    calculeObj = calculate(calculeObj, '+/-');
+    expect(calculeObj.next).toBe('-2');
+  });
+
+  test('Test dot operation', () => {
+    calculeObj = calculate(calculeObj, 'AC');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '.');
+    calculeObj = calculate(calculeObj, '5');
+    expect(calculeObj.next).toBe('2.5');
+  });
+
+  test('Test equal operation', () => {
+    calculeObj = calculate(calculeObj, 'AC');
+    calculeObj = calculate(calculeObj, '=');
+    expect(calculeObj.next).toBe(null || undefined);
+  });
+});
+
+describe('test operation results', () => {
+  let calculeObj = { total: null, next: null, operation: null };
+
+  test('Test addittions', () => {
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, '+');
+    calculeObj = calculate(calculeObj, '10');
+    expect(calculeObj.next).toBe('10');
+    calculeObj = calculate(calculeObj, '=');
+    const result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 + 10));
+  });
+
+  test('Test successive addittions', () => {
+    calculeObj = calculate(calculeObj, 'AC');
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, '+');
+    calculeObj = calculate(calculeObj, '10');
+    expect(calculeObj.next).toBe('10');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 + 10));
+    calculeObj = calculate(calculeObj, '+');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 + 10) + 10);
+  });
+
+  test('Test successive substraction with sign change', () => {
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, '-');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 - 10));
+    calculeObj = calculate(calculeObj, '-');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '+/-');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 - 10) - (-10));
+  });
+
+  test('Test successive multiplications', () => {
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, 'x');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 * 10));
+    calculeObj = calculate(calculeObj, 'x');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 * 10) * 10);
+  });
+
+  test('Test successive division with sign change', () => {
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, '÷');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseFloat(calculeObj.total, 10);
+    expect(result).toEqual((50 / 10));
+    calculeObj = calculate(calculeObj, '÷');
+    calculeObj = calculate(calculeObj, '10');
+    calculeObj = calculate(calculeObj, '+/-');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseFloat(calculeObj.total, 10);
+    expect(result).toEqual(-(50 / 10) / 10);
+  });
+
+  test('Test successive modulo with sign change', () => {
+    calculeObj = calculate(calculeObj, '50');
+    calculeObj = calculate(calculeObj, '%');
+    calculeObj = calculate(calculeObj, '15');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseInt(calculeObj.total, 10);
+    expect(result).toEqual((50 % 15));
+    calculeObj = calculate(calculeObj, '%');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '+/-');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseFloat(calculeObj.total, 10);
+    expect(result).toEqual((50 % 15) % (-2));
+  });
+
+  test('Test successive operation with dot', () => {
+    calculeObj = calculate(calculeObj, '5');
+    calculeObj = calculate(calculeObj, '.');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '+');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '.');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '=');
+    let result = parseFloat(calculeObj.total, 10);
+    expect(result).toEqual((5.2 + 2.2));
+    calculeObj = calculate(calculeObj, 'x');
+    calculeObj = calculate(calculeObj, '2');
+    calculeObj = calculate(calculeObj, '.');
+    calculeObj = calculate(calculeObj, '7');
+    calculeObj = calculate(calculeObj, '+/-');
+    calculeObj = calculate(calculeObj, '=');
+    result = parseFloat(calculeObj.total, 10);
+    const expectedResult = parseFloat(((5.2 + 2.2) * (-2.7)).toFixed(2));
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/src/components/logic/calculate.test.js
+++ b/src/components/logic/calculate.test.js
@@ -1,5 +1,5 @@
 /* params: {total, next, operation}, buttonName */
-const calculate = require('./calculate');
+import calculate from './calculate';
 
 describe('test displayed on type on buttons', () => {
   let calculeObj = { total: null, next: null, operation: null };

--- a/src/components/logic/operate.test.js
+++ b/src/components/logic/operate.test.js
@@ -1,0 +1,33 @@
+import operate from './operate';
+
+describe('Test oprations', () => {
+  test('Test addition', () => {
+    const result = operate(10, 5, '+');
+    expect(result).toEqual('15');
+  });
+
+  test('Test Substraction', () => {
+    const result = operate(10, 5, '-');
+    expect(result).toEqual('5');
+  });
+
+  test('Test Multiplication', () => {
+    const result = operate(10, 5, 'x');
+    expect(result).toEqual('50');
+  });
+
+  test('Test Divide', () => {
+    const result = operate(10, 5, '÷');
+    expect(result).toEqual('2');
+  });
+
+  test('Test Modulo', () => {
+    const result = operate(10, 5, '%');
+    expect(result).toEqual('0');
+  });
+
+  test('Test Divide', () => {
+    const result = operate(1.5, 5.2, '+');
+    expect(result).toEqual('6.7');
+  });
+});


### PR DESCRIPTION
In this pull request, @stevenmukama and I have been able to:
- Add tests for `operate.js` in `operate.test.js`
- Add tests for `calculate.js` in `calculate.test.js`
- Add a test with a snapshot to check the rendering of all components in `components.test.js`
- Add tests to simulate user interaction in `components.test.js`